### PR TITLE
 .error() is deprecated since JQuery 1.8, fix this

### DIFF
--- a/jquery.preload.js
+++ b/jquery.preload.js
@@ -79,7 +79,7 @@
 			return finish();
 		
 		var imgs = $(Array(settings.threshold+1).join('<img/>'))
-			.load(handler).error(handler).bind('abort',handler).each(fetch);
+			.load(handler).on('error',handler).bind('abort',handler).each(fetch);
 		
 		function handler( e ){
 			data.element = this;


### PR DESCRIPTION
before change: http://i.imgur.com/YUEbWbC.png
after: http://i.imgur.com/T5SetSN.png

Thank for the excellent plugin :)
